### PR TITLE
Removes favicon column.

### DIFF
--- a/import.rb
+++ b/import.rb
@@ -128,8 +128,7 @@ module SafariHistToChrome
         visit_count: url.visit_count,
         typed_count: 0,
         last_visit_time: TimeConv.to_chrome(last_visit.visit_time),
-        hidden: 0,
-        favicon_id: 0
+        hidden: 0
       ))
       url_id = @chromedb.last_insert_row_id
       unless url_id > 0


### PR DESCRIPTION
Removing the favicon column as Chrome (Version 64.0.3282.167 (Official Build) (64-bit)) on MacOS High Sierra doesn't seem to have it anymore.
Without removing this column the import script would fail.

Feel free to merge or close/decline my PR.

PS. Thank you for the script, it really help a lot.